### PR TITLE
Refactor bootstrap for multiple service accounts creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,7 @@ configure resources such as VMs, subnets and firewall rules.
 | `enable_apis`                | List of Google APIs to be enabled                            | `list(object)` | []          | No        |
 | `buckets`                    | List of buckets to create                                    | `list(object)` | []         | No        |
 | `create_gcs_backend`         | Set to true to initialize an empty gcs backend in the cwd    | `bool`     | false         | No         |
-| `sa_id`                      | The ID for the service account (e.g., 'terraform-sa')        | `string`    | ""             | No    |
-| `sa_display_name`            | Display name for the service account                         | `string`    | ""             | No    |
-| `sa_roles`                   | List of IAM roles to bind to the service account             | `list(object)` | []         | No        |
+| `service_accounts`           | List of service accounts to be created                       | `list(object)`  | []             | No    |
 
 ## 🔧 Terraform Network and Compute Variable Reference
 

--- a/environments/bootstrap/main.tf
+++ b/environments/bootstrap/main.tf
@@ -35,10 +35,11 @@ module "gcs_backend" {
 }
 
 module "service_account" {
+  for_each        = { for sa in var.service_accounts : sa.display_name => sa }
   source          = "../../modules/service_account"
-  sa_id           = var.sa_id
-  sa_display_name = var.sa_display_name
+  sa_id           = each.value.id
+  sa_display_name = each.value.display_name
   sa_project_id   = var.project_id
-  sa_roles        = var.sa_roles
+  sa_roles        = each.value.roles
   depends_on      = [module.project, module.apis]
 }

--- a/environments/bootstrap/terraform.tfvars
+++ b/environments/bootstrap/terraform.tfvars
@@ -20,10 +20,14 @@ buckets = [
   }
 ]
 create_gcs_backend = true
-sa_id              = "terraform-sa"
-sa_display_name    = "terraform-sa"
-sa_roles = [
-  "roles/compute.admin",
-  "roles/compute.networkAdmin",
-  "roles/storage.objectAdmin"
+service_accounts = [
+  {
+    id           = "terraform-sa"
+    display_name = "terraform-sa"
+    roles = [
+      "roles/compute.admin",
+      "roles/compute.networkAdmin",
+      "roles/storage.objectAdmin"
+    ]
+  }
 ]

--- a/environments/bootstrap/variables.tf
+++ b/environments/bootstrap/variables.tf
@@ -56,19 +56,13 @@ variable "create_gcs_backend" {
   default     = false
 }
 
-# Service Account
-variable "sa_id" {
-  description = "The ID for the service account (e.g., 'terraform-sa')"
-  type        = string
-  default     = ""
-}
-variable "sa_display_name" {
-  description = "Display name for the service account"
-  type        = string
-  default     = ""
-}
-variable "sa_roles" {
-  description = "List of IAM roles to bind to the service account"
-  type        = list(string)
-  default     = []
+# Service Accounts
+variable "service_accounts" {
+  description = "List of service accounts to create"
+  type = list(object({
+    id           = string
+    display_name = string
+    roles        = list(string)
+  }))
+  default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -56,21 +56,16 @@ variable "create_gcs_backend" {
   default     = false
 }
 
-# Service Account
-variable "sa_id" {
-  description = "The ID for the service account (e.g., 'terraform-sa')"
-  type        = string
-  default     = ""
-}
-variable "sa_display_name" {
-  description = "Display name for the service account"
-  type        = string
-  default     = ""
-}
-variable "sa_roles" {
-  description = "List of IAM roles to bind to the service account"
-  type        = list(string)
-  default     = []
+
+# Service Accounts
+variable "service_accounts" {
+  description = "List of service accounts to create"
+  type = list(object({
+    id           = string
+    display_name = string
+    roles        = list(string)
+  }))
+  default = []
 }
 
 # Network


### PR DESCRIPTION
The module invocation and variable input for the main procedure of the bootstrap environment
had to be adjusted in order to support the creation of multiple service accounts based on a list
of dictionaries with the necessary key - value pairs.